### PR TITLE
Add sitemaps

### DIFF
--- a/kfdb/apps/core/context_processors.py
+++ b/kfdb/apps/core/context_processors.py
@@ -10,7 +10,7 @@ def global_context(request):
         default=None,
     )
 
-    if theme_cookie:
+    if theme_cookie:  # pragma: no cover
         theme = theme_cookie
     else:
         theme = "light"

--- a/kfdb/apps/core/tests/tests.py
+++ b/kfdb/apps/core/tests/tests.py
@@ -228,14 +228,38 @@ class CoreViewsTest(TestCase):
 class SitemapsTest(TestCase):
     """Tests all sitemaps."""
 
-    def test_sitemaps(self):
+    def setUp(self):
+        """Sets up test data."""
+
+        self.channel = Channel.objects.create(name="Test Channel")
+        self.host = Host.objects.create(name="Test Crew", kf_crew=True)
+        self.show = Show.objects.create(name="Test Show")
+
+    def test_static_sitemaps(self):
+        """Tests static sitemaps."""
         sitemaps = (
             self.client.get("/sitemap.xml"),
             self.client.get("/sitemap-core.xml"),
-            self.client.get("/sitemap-hosts.xml"),
-            self.client.get("/sitemap-shows.xml"),
-            self.client.get("/sitemap-channels.xml"),
             self.client.get("/sitemap-static.xml"),
         )
         for response in sitemaps:
             self.assertEqual(response.status_code, 200)
+
+    def test_model_sitemaps(self):
+        """Tests model-driven sitemaps."""
+
+        sitemap_hosts = self.client.get("/sitemap-hosts.xml")
+        sitemap_shows = self.client.get("/sitemap-shows.xml")
+        sitemap_channels = self.client.get("/sitemap-channels.xml")
+
+        self.assertIn(
+            f"/hosts/{self.host.url_type}/{self.host.slug}/".encode(),
+            sitemap_hosts.content,
+        )
+        self.assertIn(
+            f"/shows/{self.show.slug}/".encode(), sitemap_shows.content
+        )
+        self.assertIn(
+            f"/channels/{self.channel.slug}/".encode(),
+            sitemap_channels.content,
+        )

--- a/kfdb/apps/core/tests/tests.py
+++ b/kfdb/apps/core/tests/tests.py
@@ -223,3 +223,19 @@ class CoreViewsTest(TestCase):
         view.setup(request)
         response = view.get(request)
         self.assertEqual(response.status_code, 200)
+
+
+class SitemapsTest(TestCase):
+    """Tests all sitemaps."""
+
+    def test_sitemaps(self):
+        sitemaps = (
+            self.client.get("/sitemap.xml"),
+            self.client.get("/sitemap-core.xml"),
+            self.client.get("/sitemap-hosts.xml"),
+            self.client.get("/sitemap-shows.xml"),
+            self.client.get("/sitemap-channels.xml"),
+            self.client.get("/sitemap-static.xml"),
+        )
+        for response in sitemaps:
+            self.assertEqual(response.status_code, 200)

--- a/kfdb/config/settings.py
+++ b/kfdb/config/settings.py
@@ -27,6 +27,7 @@ THIRD_PARTY_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
+    "django.contrib.sitemaps",
     "django.contrib.staticfiles",
     "rest_framework",
     "rest_framework_json_api",

--- a/kfdb/config/sitemaps.py
+++ b/kfdb/config/sitemaps.py
@@ -1,0 +1,75 @@
+from django.contrib.sitemaps import Sitemap
+from django.urls import reverse
+
+from apps.channels.models import Channel
+from apps.hosts.models import Host
+from apps.shows.models import Show
+
+
+class CoreViewSitemap(Sitemap):
+    changefreq = "weekly"
+    protocol = "https"
+    priority = 1.0
+
+    def items(self):
+        return (
+            "hero",
+            "index",
+            "api_docs",
+        )
+
+    def location(self, item):
+        return reverse(item)
+
+
+class StaticViewSitemap(Sitemap):
+    changefreq = "yearly"
+    protocol = "https"
+    priority = 0.2
+
+    def items(self):
+        return ("privacy_policy",)
+        # return ("privacy_policy", "about", "support")
+
+    def location(self, item):
+        return reverse(item)
+
+
+class ChannelSitemap(Sitemap):
+    changefreq = "weekly"
+    protocol = "https"
+    priority = 0.4
+
+    def items(self):
+        return Channel.objects.all().values("slug").order_by("pk")
+
+    def location(self, channel):
+        return f"/channels/{channel['slug']}/"
+
+
+class ShowSitemap(Sitemap):
+    changefreq = "weekly"
+    protocol = "https"
+    priority = 0.6
+
+    def items(self):
+        return Show.objects.all().values("slug").order_by("pk")
+
+    def location(self, show):
+        return f"/shows/{show['slug']}/"
+
+
+class HostSitemap(Sitemap):  # pragma: no cover
+    changefreq = "weekly"
+    protocol = "https"
+    priority = 0.8
+
+    def items(self):
+        return (
+            Host.objects.all()
+            .only("slug", "kf_crew", "part_timer")
+            .order_by("-kf_crew", "-part_timer", "name")
+        )
+
+    def location(self, host):
+        return f"/hosts/{host.url_type}/{host.slug}/"

--- a/kfdb/config/sitemaps.py
+++ b/kfdb/config/sitemaps.py
@@ -59,7 +59,7 @@ class ShowSitemap(Sitemap):
         return f"/shows/{show['slug']}/"
 
 
-class HostSitemap(Sitemap):  # pragma: no cover
+class HostSitemap(Sitemap):
     changefreq = "weekly"
     protocol = "https"
     priority = 0.8

--- a/kfdb/config/urls.py
+++ b/kfdb/config/urls.py
@@ -2,7 +2,24 @@
 
 from django.conf import settings
 from django.conf.urls.static import static
+from django.contrib.sitemaps.views import index, sitemap
 from django.urls import include, path
+
+from .sitemaps import (
+    ChannelSitemap,
+    CoreViewSitemap,
+    ShowSitemap,
+    HostSitemap,
+    StaticViewSitemap,
+)
+
+sitemaps = {
+    "core": CoreViewSitemap,
+    "hosts": HostSitemap,
+    "shows": ShowSitemap,
+    "channels": ChannelSitemap,
+    "static": StaticViewSitemap,
+}
 
 
 urlpatterns = [
@@ -12,6 +29,22 @@ urlpatterns = [
     path("", include("apps.hosts.urls")),
     path("", include("apps.shows.urls")),
     path("", include("apps.videos.urls")),
+]
+
+# Sitemaps
+urlpatterns += [
+    path(
+        "sitemap.xml",
+        index,
+        {"sitemaps": sitemaps},
+        name="django.contrib.sitemaps.views.index",
+    ),
+    path(
+        "sitemap-<section>.xml",
+        sitemap,
+        {"sitemaps": sitemaps},
+        name="django.contrib.sitemaps.views.sitemap",
+    ),
 ]
 
 if settings.DEBUG:  # pragma: no cover


### PR DESCRIPTION
`"about"` and `"support"` need to be added to `StaticViewSitemap.items()` once the pages are created.